### PR TITLE
Enable CORS for image data loading

### DIFF
--- a/dist/windgl.cjs.js
+++ b/dist/windgl.cjs.js
@@ -197,7 +197,11 @@ WindGL.prototype.setSource = function setSource (ref) {
   getJSON(url, function (windData) {
     var windImage = new Image();
     windData.image = windImage;
-    windImage.src = windData.tiles[0].replace(/{(z|x|y)}/g, "0");
+    var url = windData.tiles[0].replace(/{(z|x|y)}/g, "0");
+    if (new URL(url).origin !== window.location.origin) {
+      windImage.crossOrigin = "anonymous";
+    }
+    windImage.src = url;
     windImage.onload = function () { return this$1.setWind(windData); };
   });
 };

--- a/dist/windgl.esm.js
+++ b/dist/windgl.esm.js
@@ -195,7 +195,11 @@ WindGL.prototype.setSource = function setSource (ref) {
   getJSON(url, function (windData) {
     var windImage = new Image();
     windData.image = windImage;
-    windImage.src = windData.tiles[0].replace(/{(z|x|y)}/g, "0");
+    var url = windData.tiles[0].replace(/{(z|x|y)}/g, "0");
+    if (new URL(url).origin !== window.location.origin) {
+      windImage.crossOrigin = "anonymous";
+    }
+    windImage.src = url;
     windImage.onload = function () { return this$1.setWind(windData); };
   });
 };

--- a/dist/windgl.umd.js
+++ b/dist/windgl.umd.js
@@ -201,7 +201,11 @@
     getJSON(url, function (windData) {
       var windImage = new Image();
       windData.image = windImage;
-      windImage.src = windData.tiles[0].replace(/{(z|x|y)}/g, "0");
+      var url = windData.tiles[0].replace(/{(z|x|y)}/g, "0");
+      if (new URL(url).origin !== window.location.origin) {
+        windImage.crossOrigin = "anonymous";
+      }
+      windImage.src = url;
       windImage.onload = function () { return this$1.setWind(windData); };
     });
   };

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,11 @@ class WindGL {
     getJSON(url, windData => {
       const windImage = new Image();
       windData.image = windImage;
-      windImage.src = windData.tiles[0].replace(/{(z|x|y)}/g, "0");
+      const url = windData.tiles[0].replace(/{(z|x|y)}/g, "0");
+      if (new URL(url).origin !== window.location.origin) {
+        windImage.crossOrigin = "anonymous";
+      }
+      windImage.src = url;
       windImage.onload = () => this.setWind(windData);
     });
   }


### PR DESCRIPTION
This change enables sending CORS requests if we detect that the origin of the requested data image is different from the users current origin.