### PR TITLE
Delete commands destroy context

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -208,8 +208,6 @@ export default class Layer {
 
   // This is called when the map is destroyed or the gl context lost.
   onRemove(map) {
-    delete this.gl;
-    delete this.map;
     map.off("zoom", this.zoom);
   }
 


### PR DESCRIPTION
delete commands destroy the gl context causing failure when removing and adding layers to change the source.